### PR TITLE
Avoiding python bug by fixing the timestamp

### DIFF
--- a/hearthstone/utils.py
+++ b/hearthstone/utils.py
@@ -66,7 +66,7 @@ STANDARD_SETS = {
 
 
 ZODIAC_ROTATION_DATES = {
-	ZodiacYear.PRE_STANDARD: datetime.fromtimestamp(0),
+	ZodiacYear.PRE_STANDARD: datetime.fromtimestamp(86400),
 	ZodiacYear.KRAKEN: datetime(2016, 4, 26),
 	ZodiacYear.MAMMOTH: datetime(2017, 4, 7),
 }


### PR DESCRIPTION
Addressing the bug present in Windows starting Python 3.6:
https://bugs.python.org/issue29097

Timestamps below 86400 result in OSError: [Errno 22] Invalid argument